### PR TITLE
fix: Relax validations when posting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ export async function run(
       return http
         .post('/posts.json', {
           raw: postBody,
-         topic_id: discourseTopicId,
+          topic_id: discourseTopicId,
           reply_to_post_number: discourseTopicId,
           skip_validations: true
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,8 +41,9 @@ export async function run(
       return http
         .post('/posts.json', {
           raw: postBody,
-          topic_id: discourseTopicId,
-          reply_to_post_number: discourseTopicId
+         topic_id: discourseTopicId,
+          reply_to_post_number: discourseTopicId,
+          skip_validations: true
         })
         .then(({ data }) => {
           core.debug(JSON.stringify(data, null, 2))


### PR DESCRIPTION
Discourse uses `422`  for validation errors (which is ok, I guess), and filter for duplicates and so on. Guess as a means of spam protection. But the response doesn't tell you what's wrong.

Buuuut: There's an undocumented parameter called skip_validations to turn that off :see_no_evil:

This set me on the right track: https://meta.discourse.org/t/difficult-to-work-out-reason-for-http-422-error-in-api/138141/4
